### PR TITLE
Update portfolio to reflect Afresh Technologies role

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,10 @@ import { OrderedList } from '../components/typography/ordered-list';
 import { Paragraph } from '../components/typography/paragraph';
 import { UnorderedList } from '../components/typography/unordered-list';
 
+// Rendered per-request so values computed at render time (e.g. my age in the
+// introduction) stay current instead of being frozen at build time.
+export const dynamic = 'force-dynamic';
+
 export default function Home() {
   return (
     <Stack>
@@ -60,10 +64,10 @@ export default function Home() {
         </ListItem>
         <ListItem>
           <strong>Work Projects:</strong> I cannot discuss these in detail due
-          to confidentiality. What I can say is that I have developed a platform
-          of applications and libraries for my employer who is in the AgTech
-          (Agricultural Technology) sector. Some of these projects involve AI,
-          some are more traditional business apps.
+          to confidentiality. What I can say is that at Afresh Technologies I
+          work on the DC (distribution center) product, building full stack
+          applications that help grocers forecast demand for fresh food and
+          reduce food waste across the supply chain.
         </ListItem>
       </UnorderedList>
       <HorizontalRow />

--- a/src/components/portfolio-page/introduction.tsx
+++ b/src/components/portfolio-page/introduction.tsx
@@ -7,18 +7,21 @@ export function Introduction() {
       <Paragraph>
         My name is Ben McLean, I&apos;m a {getAgeInYears()} year old software
         developer. I&apos;m a passionate problem solver and I enjoy developing
-        high-quality well crafted software. I&apos;m currently employed by
-        Catalyst Reaction Technologies Ltd. Catalyst develops software for
-        companies in the Agricultural sector. I maintain a system of several
-        frontend and backend applications, as well as associated software
-        libraries.
+        high-quality well crafted software. I&apos;m currently a full stack
+        engineer at Afresh Technologies, where I work on the DC (distribution
+        center) product. Afresh builds AI-powered software that helps grocers
+        forecast demand for fresh food, cutting down on food waste across the
+        supply chain — a mission I&apos;m proud to contribute to.
       </Paragraph>
       <Paragraph>
-        My previous role was at Inovatech Engineering, a Lincoln Electric
-        company. I helped maintain a large .NET/C# codebase, but also did some
-        projects with TypeScript, React and Python. I worked on robotic CNC
-        plasma cutters, and developed software for CAD/CAM, geometry, and
-        robotics applications.
+        Previously I worked at Catalyst Reaction Technologies Ltd., where I
+        developed software for companies in the Agricultural sector, maintaining
+        a system of several frontend and backend applications along with
+        associated software libraries. Before that I was at Inovatech
+        Engineering, a Lincoln Electric company, where I helped maintain a large
+        .NET/C# codebase and also did some projects with TypeScript, React and
+        Python. I worked on robotic CNC plasma cutters, and developed software
+        for CAD/CAM, geometry, and robotics applications.
       </Paragraph>
       <Paragraph>
         In June 2022 I graduated Cum Laude from the University of Ottawa. I


### PR DESCRIPTION
## Summary
- Update the introduction to describe my current role as a full stack engineer at **Afresh Technologies**, working on the **DC (distribution center)** product, with a note on Afresh's mission (AI demand forecasting to reduce fresh-food waste). Catalyst Reaction Technologies and Inovatech Engineering are moved into a "previously" paragraph.
- Rewrite the home page "Work Projects" bullet to reflect the Afresh DC work instead of the prior AgTech employer.
- Opt the home page out of static generation (`export const dynamic = 'force-dynamic'`) so the computed age in the introduction stays current per-request instead of being frozen at build time. The route now reports as `ƒ (Dynamic)` in the build output.

## Testing
- `yarn build` — home page compiles and is now server-rendered on demand. (`/minesweeper` still requires `NEXT_PUBLIC_SUPABASE_*` env vars to collect page data; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)